### PR TITLE
Add a disjuncts-only parser.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Perform the following steps at the shell prompt:
     cd build
     cmake ..
     make
+    sudo make install
 ```
 Libraries will be built into subdirectories within build, mirroring
 the structure of the source directory root.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@ This repo provides an Atomese API for
 Grammar dictionaries and parse results to be accessed from the
 AtomSpace.
 
+Status
+------
+### Version 1.0
+The code here has been used in production for many years.
+
+However, there are still some things that would be nice to have.
+This includes:
+* Placing costs on the parse results.
+* Reporting costs in dictionary lookups.
+
 Prerequisites
 -------------
 The following packages must first be built and installed.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,9 +1,10 @@
 Link Grammar Atomese Examples
 =============================
 
-This diectory contains some examples of how to use the Link Grammar
+This directory contains some examples of how to use the Link Grammar
 Atomese API. It demostrates how to look up dictionary words, and how
 to parsee sentences.  A basic familiarity with Link Grammar is assumed.
 
 * `dict-lookup.scm` -- Look up individual words in the dictionary.
 * `parse.scm` -- Parse sentences.
+* `parse-disjuncts.scm` -- Get the disjuncts used in a parse.

--- a/examples/parse-disjuncts.scm
+++ b/examples/parse-disjuncts.scm
@@ -1,0 +1,45 @@
+;
+; parse-disjuncts.scm -- Demo of getting the disjuncts used in a parse.
+;
+; The Link Grammar parser will parse natural language sentences,
+; returning a dependency graph of how the words are connected.
+; The Atomese API for the LG parser converts that graph into
+; Atomese format. This format is quite verbose, and some applications
+; do not need the full parse information. This demo illustrates how
+; to get the disjuncts, only, without the rest of the parse info.
+; -----------------------------------------------------------------
+
+; Load the guile modules
+(use-modules (opencog) (opencog exec))
+(use-modules (opencog nlp) (opencog nlp lg-parse))
+
+(use-modules (srfi srfi-1))
+
+; Parse an example sentence
+(cog-execute!
+	(LgParseDisjuncts    ; There is also a "full" parse, demoed elsewhere.
+		(PhraseNode "this is a test.")   ; The example sentence
+		(LgDictNode "en")  ; The dictionary to use - English in this case.
+		(NumberNode 1)))   ; The number of parses to perform.
+
+; To see the parse in it's full glory, it's easiest to just print
+; the entire contents of the AtomSpace.
+(cog-prt-atomspace)
+
+; Look for disjuncts, for example, you should see something like
+;
+;    (LgWordCset
+;      (WordInstanceNode "What@ec45f2db-a013-47c9-bde6-39b043d4a54a")
+;      (LgAnd
+;        (LgConnector
+;          (LgConnNode "Wn")
+;          (LgConnDirNode "-"))
+;        (LgConnector
+;          (LgConnNode "O")
+;          (LgConnDirNode "+"))))
+;
+; which says that the word `What` had the disjunct `Wn- & O+` on it.
+;
+
+; ---------------------
+; That's all, folks!

--- a/examples/parse-disjuncts.scm
+++ b/examples/parse-disjuncts.scm
@@ -26,20 +26,24 @@
 ; the entire contents of the AtomSpace.
 (cog-prt-atomspace)
 
-; Look for disjuncts, for example, you should see something like
+; One of the disjuncts will look like this:
 ;
-;    (LgWordCset
-;      (WordInstanceNode "What@ec45f2db-a013-47c9-bde6-39b043d4a54a")
+;    (LgDisjunct
+;      (WordNode "this")
 ;      (LgAnd
 ;        (LgConnector
-;          (LgConnNode "Wn")
+;          (LgConnNode "Wd")
 ;          (LgConnDirNode "-"))
 ;        (LgConnector
-;          (LgConnNode "O")
+;          (LgConnNode "Ss*b")
 ;          (LgConnDirNode "+"))))
 ;
-; which says that the word `What` had the disjunct `Wn- & O+` on it.
+; which says that the word `this` had the disjunct `Wd- & Ss*b+` on it.
 ;
+; Note that this format does NOT include any info about which
+; word-instance this was in the sentence, nor which words the
+; connectors connected to. That info is available by using the
+; `LgParseLink` parser.
 
 ; ---------------------
 ; That's all, folks!

--- a/examples/parse-disjuncts.scm
+++ b/examples/parse-disjuncts.scm
@@ -28,7 +28,7 @@
 
 ; One of the disjuncts will look like this:
 ;
-;    (LgDisjunct
+;    (LgDisjunct (ctv 1 0 1)
 ;      (WordNode "this")
 ;      (LgAnd
 ;        (LgConnector
@@ -39,6 +39,10 @@
 ;          (LgConnDirNode "+"))))
 ;
 ; which says that the word `this` had the disjunct `Wd- & Ss*b+` on it.
+; Note that the CountTruthValue on `LgDisjunct` has been set to 1.0.
+; If the parse is re-run, the count will increment by one.  If more
+; than one parse is requested, then the counts will reflect the number
+; of times a given disjunct was used in all of the parses.
 ;
 ; Note that this format does NOT include any info about which
 ; word-instance this was in the sentence, nor which words the

--- a/opencog/nlp/README.md
+++ b/opencog/nlp/README.md
@@ -16,11 +16,14 @@ Implements the `LgDictEntry` and the `LgHaveDictEntry` atoms.
 lg-parse
 --------
 Parse sentences and place parse results into the AtomSpace. Implements
-the `LgParse` atom.
+the `LgParse`, `LgParseMinimal` and `LgParseDisjuncts` Atoms.
 
 A parsed sentence consists of zero or more parses. Each parse consists
 of a sequence of `WordInstanceNode`, together with a listing of the 
-LG Links connecting those words.
+LG Links connecting those words. The `LgParseMinimal` link does less
+work, by skipping the creation of the disjuncts. The `LgParseDisjuncts`
+link does less work by creating *only* the disjuncts, and none of the
+rest of the linkage info.
 
 scm
 ---
@@ -32,4 +35,5 @@ LG markup from a parsed sentence.
 
 types
 -----
-Definition of assorted natural-language-processing Atom Types.
+Definition of assorted natural-language-processing Atom Types. These
+are used by many different OpenCog NLP subsystems.

--- a/opencog/nlp/lg-parse/LGParseLink.cc
+++ b/opencog/nlp/lg-parse/LGParseLink.cc
@@ -109,6 +109,19 @@ LGParseMinimal::LGParseMinimal(const HandleSeq&& oset, Type t)
 	init();
 }
 
+LGParseDisjuncts::LGParseDisjuncts(const HandleSeq&& oset, Type t)
+	: LGParseLink(std::move(oset), t)
+{
+	// Type must be as expected
+	if (not nameserver().isA(t, LG_PARSE_DISJUNCTS))
+	{
+		const std::string& tname = nameserver().getTypeName(t);
+		throw InvalidParamException(TRACE_INFO,
+			"Expecting an LgParseDisjuncts, got %s", tname.c_str());
+	}
+	init();
+}
+
 // =================================================================
 
 ValuePtr LGParseLink::execute(AtomSpace* as, bool silent)

--- a/opencog/nlp/lg-parse/LGParseLink.cc
+++ b/opencog/nlp/lg-parse/LGParseLink.cc
@@ -294,33 +294,10 @@ Handle LGParseLink::cvt_linkage(Linkage lkg, int i, const char* idstr,
 	int nwords = linkage_get_num_words(lkg);
 	for (int w=0; w<nwords; w++)
 	{
-		size_t sb = linkage_get_word_byte_start(lkg, w);
-		size_t eb = linkage_get_word_byte_end(lkg, w);
+		// Get the word in the sentence.
+		const char* wrd = get_word_string(lkg, w, phrstr);
 
-		// Problem: the default LG API supplies the word together with
-		// the subscript, and with word regex and guess-marks. We really
-		// do NOT want that crud. So use the byte offsets to get the
-		// actual original string.  Since LEFT-WALL and RIGHT-WALL have
-		// no offsets, we need to handle those differently.
-		// strndupa allocates on stack, no need to free.
-		const char* wrd;
-		if (eb == sb) // Both are equal to -1
-		{
-			wrd = linkage_get_word(lkg, w);
-		}
-		else
-		{
-			// eb points at the byte after the last char,
-			// its a great place to write a null byte.
-			wrd = strndupa(phrstr + sb, eb-sb);
-		}
-
-		// LEFT-WALL is not an ordinary word. Its special. Make it
-		// extra-special by adding "illegal" punctuation to it.
-		// FYI, this is compatible with Relex, relex2logic.
-		if (0 == w and 0 == strcmp(wrd, "LEFT-WALL")) wrd = "###LEFT-WALL###";
-		if (nwords-1 == w and 0 == strcmp(wrd, "RIGHT-WALL")) wrd = "###RIGHT-WALL###";
-
+		// Generate a unique UUID for that word.
 		uuid_t uu2;
 		uuid_generate(uu2);
 		char idstr2[37];
@@ -391,6 +368,7 @@ Handle LGParseLink::cvt_linkage(Linkage lkg, int i, const char* idstr,
 	return pnode;
 }
 
+// Create only the disjuncts for the parse, and nothing else.
 void LGParseLink::make_djs(Linkage lkg, const char* phrstr,
                            AtomSpace* as) const
 {
@@ -399,35 +377,10 @@ void LGParseLink::make_djs(Linkage lkg, const char* phrstr,
 	int nwords = linkage_get_num_words(lkg);
 	for (int w=0; w<nwords; w++)
 	{
-		size_t sb = linkage_get_word_byte_start(lkg, w);
-		size_t eb = linkage_get_word_byte_end(lkg, w);
-
-		// Problem: the default LG API supplies the word together with
-		// the subscript, and with word regex and guess-marks. We really
-		// do NOT want that crud. So use the byte offsets to get the
-		// actual original string.  Since LEFT-WALL and RIGHT-WALL have
-		// no offsets, we need to handle those differently.
-		// strndupa allocates on stack, no need to free.
-		const char* wrd;
-		if (eb == sb) // Both are equal to -1
-		{
-			wrd = linkage_get_word(lkg, w);
-		}
-		else
-		{
-			// eb points at the byte after the last char,
-			// its a great place to write a null byte.
-			wrd = strndupa(phrstr + sb, eb-sb);
-		}
-
-		// LEFT-WALL is not an ordinary word. Its special. Make it
-		// extra-special by adding "illegal" punctuation to it.
-		// FYI, this is compatible with Relex, relex2logic.
-		if (0 == w and 0 == strcmp(wrd, "LEFT-WALL")) wrd = "###LEFT-WALL###";
-		if (nwords-1 == w and 0 == strcmp(wrd, "RIGHT-WALL")) wrd = "###RIGHT-WALL###";
-
 		HandleSeq conseq = make_conseq(lkg, w);
 		if (0 == conseq.size()) continue;
+
+		const char* wrd = get_word_string(lkg, w, phrstr);
 
 		// Set up the disjuncts on each word
 		as->add_link(LG_DISJUNCT,
@@ -479,6 +432,47 @@ HandleSeq LGParseLink::make_conseq(Linkage lkg, int w) const
 	}
 
 	return conseq;
+}
+
+const char* LGParseLink::get_word_string(Linkage lkg, int w,
+                                         const char* phrstr) const
+{
+#define BUFSZ 240
+	static thread_local char buff[BUFSZ];
+
+	size_t sb = linkage_get_word_byte_start(lkg, w);
+	size_t eb = linkage_get_word_byte_end(lkg, w);
+
+	// Problem: the default LG API supplies the word together with
+	// the subscript, and with word regex and guess-marks. We really
+	// do NOT want that crud. So use the byte offsets to get the
+	// actual original string.  Since LEFT-WALL and RIGHT-WALL have
+	// no offsets, we need to handle those differently.
+	if (eb != sb) // Neither are equal to -1
+	{
+		size_t len = eb-sb;
+		if (BUFSZ <= len)
+			throw FatalErrorException(TRACE_INFO,
+				"LGParseLink: Unexpectly long word; length=%lu", len);
+
+		strncpy(buff, phrstr + sb, len);
+		buff[len] = 0;
+		return buff;
+	}
+
+	const char* wrd = linkage_get_word(lkg, w);
+
+	// LEFT-WALL is not an ordinary word. Its special. Make it
+	// extra-special by adding "illegal" punctuation to it.
+	// FYI, this is compatible with Relex, relex2logic.
+	if (0 == w and 0 == strcmp(wrd, "LEFT-WALL"))
+		return "###LEFT-WALL###";
+
+	int nwords = linkage_get_num_words(lkg);
+	if (nwords-1 == w and 0 == strcmp(wrd, "RIGHT-WALL"))
+		return "###RIGHT-WALL###";
+
+	return wrd;
 }
 
 DEFINE_LINK_FACTORY(LGParseLink, LG_PARSE_LINK)

--- a/opencog/nlp/lg-parse/LGParseLink.cc
+++ b/opencog/nlp/lg-parse/LGParseLink.cc
@@ -261,7 +261,7 @@ ValuePtr LGParseLink::execute(AtomSpace* as, bool silent)
 		Linkage lkg = linkage_create(i, sent, opts);
 		if (djonly)
 		{
-			make_djs(lkg, i, as);
+			make_djs(lkg, phrstr, as);
 		}
 		else
 		{
@@ -391,7 +391,8 @@ Handle LGParseLink::cvt_linkage(Linkage lkg, int i, const char* idstr,
 	return pnode;
 }
 
-Handle LGParseLink::make_djs(Linkage lkg, AtomSpace* as) const
+void LGParseLink::make_djs(Linkage lkg, const char* phrstr,
+                           AtomSpace* as) const
 {
 	// Loop over all the words.
 	HandleSeq wrds;
@@ -425,7 +426,7 @@ Handle LGParseLink::make_djs(Linkage lkg, AtomSpace* as) const
 		if (0 == w and 0 == strcmp(wrd, "LEFT-WALL")) wrd = "###LEFT-WALL###";
 		if (nwords-1 == w and 0 == strcmp(wrd, "RIGHT-WALL")) wrd = "###RIGHT-WALL###";
 
-		HandleSeq conseq = make_conseq(lkg);
+		HandleSeq conseq = make_conseq(lkg, w);
 		if (0 == conseq.size()) continue;
 
 		// Set up the disjuncts on each word
@@ -433,8 +434,6 @@ Handle LGParseLink::make_djs(Linkage lkg, AtomSpace* as) const
 			as->add_node(WORD_NODE, wrd),
 			as->add_link(LG_AND, std::move(conseq)));
 	}
-
-	return pnode;
 }
 
 /// Convert the disjunct to atomese.

--- a/opencog/nlp/lg-parse/LGParseLink.cc
+++ b/opencog/nlp/lg-parse/LGParseLink.cc
@@ -383,9 +383,12 @@ void LGParseLink::make_djs(Linkage lkg, const char* phrstr,
 		const char* wrd = get_word_string(lkg, w, phrstr);
 
 		// Set up the disjuncts on each word
-		as->add_link(LG_DISJUNCT,
+		Handle dj = as->add_link(LG_DISJUNCT,
 			as->add_node(WORD_NODE, wrd),
 			as->add_link(LG_AND, std::move(conseq)));
+
+		// Increment by exactly one, every time it appears.
+		as->increment_countTV(dj);
 	}
 }
 

--- a/opencog/nlp/lg-parse/LGParseLink.cc
+++ b/opencog/nlp/lg-parse/LGParseLink.cc
@@ -245,8 +245,9 @@ ValuePtr LGParseLink::execute(AtomSpace* as, bool silent)
 	Handle snode(as->add_node(SENTENCE_NODE, sentstr));
 
 	// Avoid generating big piles of Atoms, if the user did not
-	// want them. (The extra Atoms deescribe disjuncts, etc.)
+	// want them. (The extra Atoms describe disjuncts, etc.)
 	bool minimal = (get_type() == LG_PARSE_MINIMAL);
+	bool djonly = (get_type() == LG_PARSE_DISJUNCTS);
 
 	// There are only so many parses available.
 	int num_available = sentence_num_linkages_post_processed(sent);
@@ -258,8 +259,15 @@ ValuePtr LGParseLink::execute(AtomSpace* as, bool silent)
 		if (0 < sentence_num_violations(sent, i)) continue;
 		jct ++;
 		Linkage lkg = linkage_create(i, sent, opts);
-		Handle pnode = cvt_linkage(lkg, i, sentstr, phrstr, minimal, as);
-		as->add_link(PARSE_LINK, pnode, snode);
+		if (djonly)
+		{
+			make_djs(lkg, i, as);
+		}
+		else
+		{
+			Handle pnode = cvt_linkage(lkg, i, sentstr, phrstr, minimal, as);
+			as->add_link(PARSE_LINK, pnode, snode);
+		}
 		linkage_delete(lkg);
 	}
 
@@ -272,6 +280,7 @@ ValuePtr LGParseLink::execute(AtomSpace* as, bool silent)
 
 static std::atomic<unsigned long> wcnt;
 
+// Take a single linkage, and stuff it into the AtomSpace.
 Handle LGParseLink::cvt_linkage(Linkage lkg, int i, const char* idstr,
                                 const char* phrstr,
                                 bool minimal, AtomSpace* as) const
@@ -332,49 +341,13 @@ Handle LGParseLink::cvt_linkage(Linkage lkg, int i, const char* idstr,
 		if (minimal) continue;
 
 		// Convert the disjunct to atomese.
-		// This requires parsing a string. Fortunately, the
-		// string is a very simple format.
-		const char* djstr = linkage_get_disjunct_str(lkg, w);
+		HandleSeq conseq = make_conseq(lkg, w);
 
-		HandleSeq conseq;
-		const char* p = djstr;
-		while (*p)
-		{
-			while (' ' == *p) p++;
-			if (0 == *p) break;
-			bool multi = false;
-			if ('@' == *p) { multi = true; p++; }
-			const char* s = strchr(p, ' ');
-			size_t len = s-p-1;
-			if (NULL == s) len = strlen(p) - 1;
-			char cstr[60];
-			if (60 <= len)
-				throw RuntimeException(TRACE_INFO,
-					"LGParseLink: Dictionary has a bug; Uuexpectedly long connector=%s", djstr);
-			strncpy(cstr, p, len);
-			cstr[len] = 0;
-			Handle con(createNode(LG_CONN_NODE, cstr));
-			cstr[0] = *(p+len);
-			cstr[1] = 0;
-			Handle dir(createNode(LG_CONN_DIR_NODE, cstr));
-			p = p+len+1;
-
-			HandleSeq cono;
-			cono.push_back(con);
-			cono.push_back(dir);
-			if (multi)
-			{
-				Handle mu(createNode(LG_CONN_MULTI_NODE, "@"));
-				cono.push_back(mu);
-			}
-			Handle conl(createLink(std::move(cono), LG_CONNECTOR));
-			conseq.push_back(conl);
-		}
+		if (0 == conseq.size()) continue;
 
 		// Set up the disjuncts on each word
-		if (0 < conseq.size())
-			as->add_link(LG_WORD_CSET, winst,
-				as->add_link(LG_AND, std::move(conseq)));
+		as->add_link(LG_WORD_CSET, winst,
+			as->add_link(LG_AND, std::move(conseq)));
 	}
 
 	// Loop over all the links
@@ -416,6 +389,97 @@ Handle LGParseLink::cvt_linkage(Linkage lkg, int i, const char* idstr,
 	}
 
 	return pnode;
+}
+
+Handle LGParseLink::make_djs(Linkage lkg, AtomSpace* as) const
+{
+	// Loop over all the words.
+	HandleSeq wrds;
+	int nwords = linkage_get_num_words(lkg);
+	for (int w=0; w<nwords; w++)
+	{
+		size_t sb = linkage_get_word_byte_start(lkg, w);
+		size_t eb = linkage_get_word_byte_end(lkg, w);
+
+		// Problem: the default LG API supplies the word together with
+		// the subscript, and with word regex and guess-marks. We really
+		// do NOT want that crud. So use the byte offsets to get the
+		// actual original string.  Since LEFT-WALL and RIGHT-WALL have
+		// no offsets, we need to handle those differently.
+		// strndupa allocates on stack, no need to free.
+		const char* wrd;
+		if (eb == sb) // Both are equal to -1
+		{
+			wrd = linkage_get_word(lkg, w);
+		}
+		else
+		{
+			// eb points at the byte after the last char,
+			// its a great place to write a null byte.
+			wrd = strndupa(phrstr + sb, eb-sb);
+		}
+
+		// LEFT-WALL is not an ordinary word. Its special. Make it
+		// extra-special by adding "illegal" punctuation to it.
+		// FYI, this is compatible with Relex, relex2logic.
+		if (0 == w and 0 == strcmp(wrd, "LEFT-WALL")) wrd = "###LEFT-WALL###";
+		if (nwords-1 == w and 0 == strcmp(wrd, "RIGHT-WALL")) wrd = "###RIGHT-WALL###";
+
+		HandleSeq conseq = make_conseq(lkg);
+		if (0 == conseq.size()) continue;
+
+		// Set up the disjuncts on each word
+		as->add_link(LG_DISJUNCT,
+			as->add_node(WORD_NODE, wrd),
+			as->add_link(LG_AND, std::move(conseq)));
+	}
+
+	return pnode;
+}
+
+/// Convert the disjunct to atomese.
+HandleSeq LGParseLink::make_conseq(Linkage lkg, int w) const
+{
+	// This requires parsing a string. Fortunately, the
+	// string is a very simple format.
+	const char* djstr = linkage_get_disjunct_str(lkg, w);
+
+	HandleSeq conseq;
+	const char* p = djstr;
+	while (*p)
+	{
+		while (' ' == *p) p++;
+		if (0 == *p) break;
+		bool multi = false;
+		if ('@' == *p) { multi = true; p++; }
+		const char* s = strchr(p, ' ');
+		size_t len = s-p-1;
+		if (NULL == s) len = strlen(p) - 1;
+		char cstr[60];
+		if (60 <= len)
+			throw RuntimeException(TRACE_INFO,
+				"LGParseLink: Dictionary has a bug; Uuexpectedly long connector=%s", djstr);
+		strncpy(cstr, p, len);
+		cstr[len] = 0;
+		Handle con(createNode(LG_CONN_NODE, cstr));
+		cstr[0] = *(p+len);
+		cstr[1] = 0;
+		Handle dir(createNode(LG_CONN_DIR_NODE, cstr));
+		p = p+len+1;
+
+		HandleSeq cono;
+		cono.push_back(con);
+		cono.push_back(dir);
+		if (multi)
+		{
+			Handle mu(createNode(LG_CONN_MULTI_NODE, "@"));
+			cono.push_back(mu);
+		}
+		Handle conl(createLink(std::move(cono), LG_CONNECTOR));
+		conseq.push_back(conl);
+	}
+
+	return conseq;
 }
 
 DEFINE_LINK_FACTORY(LGParseLink, LG_PARSE_LINK)

--- a/opencog/nlp/lg-parse/LGParseLink.h
+++ b/opencog/nlp/lg-parse/LGParseLink.h
@@ -49,7 +49,7 @@ class LGParseLink : public FunctionLink
 protected:
 	void init();
 	HandleSeq make_conseq(Linkage, int) const;
-	Handle make_djs(Linkage, AtomSpace*) const;
+	void make_djs(Linkage, const char*, AtomSpace*) const;
 	Handle cvt_linkage(Linkage, int, const char*, const char*,
 	                   bool, AtomSpace*) const;
 

--- a/opencog/nlp/lg-parse/LGParseLink.h
+++ b/opencog/nlp/lg-parse/LGParseLink.h
@@ -70,21 +70,22 @@ public:
 	LGParseMinimal& operator=(const LGParseMinimal&) = delete;
 };
 
-typedef std::shared_ptr<LGParseLink> LGParseLinkPtr;
-static inline LGParseLinkPtr LGParseLinkCast(const Handle& h)
-	{ return std::dynamic_pointer_cast<LGParseLink>(h); }
-static inline LGParseLinkPtr LGParseLinkCast(AtomPtr a)
-	{ return std::dynamic_pointer_cast<LGParseLink>(a); }
+class LGParseDisjuncts : public LGParseLink
+{
+public:
+	LGParseDisjuncts(const HandleSeq&&, Type=LG_PARSE_DISJUNCTS);
+	LGParseDisjuncts(const LGParseDisjuncts&) = delete;
+	LGParseDisjuncts& operator=(const LGParseDisjuncts&) = delete;
+};
 
-#define createLGParseLink std::make_shared<LGParseLink>
+LINK_PTR_DECL(LGParseLink)
+#define createLGParseLink CREATE_DECL(LGParseLink)
 
-typedef std::shared_ptr<LGParseMinimal> LGParseMinimalPtr;
-static inline LGParseMinimalPtr LGParseMinimalCast(const Handle& h)
-	{ return std::dynamic_pointer_cast<LGParseMinimal>(h); }
-static inline LGParseMinimalPtr LGParseMinimalCast(AtomPtr a)
-	{ return std::dynamic_pointer_cast<LGParseMinimal>(a); }
+LINK_PTR_DECL(LGParseMinimal)
+#define createLGParseMinimal CREATE_DECL(LGParseMinimal)
 
-#define createLGParseMinimal std::make_shared<LGParseMinimal>
+LINK_PTR_DECL(LGParseDisjuncts)
+#define createLGParseDisjuncts CREATE_DECL(LGParseDisjuncts)
 
 /** @}*/
 }

--- a/opencog/nlp/lg-parse/LGParseLink.h
+++ b/opencog/nlp/lg-parse/LGParseLink.h
@@ -48,6 +48,7 @@ class LGParseLink : public FunctionLink
 {
 protected:
 	void init();
+	const char* get_word_string(Linkage, int, const char*) const;
 	HandleSeq make_conseq(Linkage, int) const;
 	void make_djs(Linkage, const char*, AtomSpace*) const;
 	Handle cvt_linkage(Linkage, int, const char*, const char*,

--- a/opencog/nlp/lg-parse/LGParseLink.h
+++ b/opencog/nlp/lg-parse/LGParseLink.h
@@ -48,6 +48,8 @@ class LGParseLink : public FunctionLink
 {
 protected:
 	void init();
+	HandleSeq make_conseq(Linkage, int) const;
+	Handle make_djs(Linkage, AtomSpace*) const;
 	Handle cvt_linkage(Linkage, int, const char*, const char*,
 	                   bool, AtomSpace*) const;
 

--- a/opencog/nlp/lg-parse/README.md
+++ b/opencog/nlp/lg-parse/README.md
@@ -23,7 +23,7 @@ The expected format of an LgParseLink is:
 
 When executed, the result of parsing the phrase text, using the
 specified dictionary, is placed in the atomspace.  Execution
-returns a Sentencenode pointing at the parse results.  If the third,
+returns a SentenceNode pointing at the parse results.  If the third,
 optional NumberNode is present, then that will be the number of
 parses that are captured. If the NumberNode is not present, it
 defaults to four.
@@ -35,6 +35,14 @@ insert the resulting disjuncts into the AtomSpace. As the disjuncts
 are quite verbose, this significantly reduces the number of atoms
 placed in the AtomSpace.
 
+LgParseDisjuncts
+----------------
+This performs the same parse as `LgParseLink`; however, it does not
+insert the resulting word instances and linkages into the AtomSpace;
+instead, it ONLY inserts the disjuncts.  As the linkages are quite
+verbose, this significantly reduces the number of atoms placed in
+the AtomSpace.
+
 Example
 -------
 Here's a working example:
@@ -44,6 +52,9 @@ Here's a working example:
     (LgDictNode "en") (NumberNode 1)))
 (cog-prt-atomspace)
 ```
+
+More examples can be found in the top-level
+[`examples`](../../../examples) directory.
 
 Notes
 -----
@@ -59,8 +70,14 @@ this means that there are two ways of getting parsed text into the
 atomspace: using this link, or using the RelEx server.  There are
 competing pros and cons of doing it each way:
 
+* The RelEx server is deprecated/obsolete. It still works, but there
+  no support for it any more. No bug-fixes, no active development.
+
 * The RelEx server is a network server, and can be run on any
   network-connected machine.
+
+* If you want to have a networked LG parser server, you can do this
+  with the `CogStoraeNode`. See the examples directory.
 
 * The RelEx server generates scheme strings, which must be parsed by
   the scheme interpreter in OpenCog. This adds a lot of overhead, and

--- a/opencog/nlp/types/atom_types.script
+++ b/opencog/nlp/types/atom_types.script
@@ -54,6 +54,7 @@ LG_DICT_ENTRY <- FUNCTION_LINK
 // Parser - parses sentences.
 LG_PARSE_LINK <- FUNCTION_LINK
 LG_PARSE_MINIMAL <- LG_PARSE_LINK
+LG_PARSE_DISJUNCTS <- LG_PARSE_LINK
 
 // Connector: same meaning and syntax as in link-grammar, except that
 // the direction and the multi-connector parts get distinct types.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,8 +12,4 @@ SET(GUILE_LOAD_PATH "${PROJECT_BINARY_DIR}/opencog/scm")
 INCLUDE_DIRECTORIES(${CMAKE_BINARY_DIR})
 
 # Perform tests in component-dependency order, as much as possible.
-IF (CXXTEST_FOUND)
-
-	# ADD_SUBDIRECTORY (nlp)
-
-ENDIF (CXXTEST_FOUND)
+ADD_SUBDIRECTORY (lg-parse)

--- a/tests/lg-parse/CMakeLists.txt
+++ b/tests/lg-parse/CMakeLists.txt
@@ -1,0 +1,2 @@
+
+ADD_GUILE_TEST(TestDisjuncts test-disjuncts.scm)

--- a/tests/lg-parse/test-disjuncts.scm
+++ b/tests/lg-parse/test-disjuncts.scm
@@ -1,0 +1,43 @@
+;
+; test-disjuncts.scm
+;
+; Super-simple unit test, based on example
+
+(use-modules (srfi srfi-64))
+(use-modules (opencog))
+(use-modules (opencog exec))
+(use-modules (opencog nlp))
+(use-modules (opencog nlp lg-parse))
+(use-modules (opencog test-runner))
+
+(opencog-test-runner)
+
+(define tname "lg-parse-disjunct-test")
+(test-begin tname)
+
+(cog-execute!
+	(LgParseDisjuncts
+		(PhraseNode "this is a test.")
+		(LgDictNode "en")
+		(NumberNode 55)))
+
+(define test-dj
+	(cog-link 'LgDisjunct
+		(WordNode "test")
+		(LgAnd
+			(LgConnector
+				(LgConnNode "Ds**c")
+				(LgConnDirNode "-"))
+			(LgConnector
+				(LgConnNode "Os")
+				(LgConnDirNode "-")))))
+
+(test-assert "Disjunct exists"
+	(not (eq? #f test-dj)))
+
+(test-approximate "Disjunct has correct count"
+	4.0 (cog-count test-dj) 1.0d-6)
+
+(test-end tname)
+
+(opencog-test-end)


### PR DESCRIPTION
For the learning project, only the disjuncts are needed, and not the rest of the parse.  So add this capability as a stand-alone feature. 