### PR TITLE
AtomSpace dictionary config

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -8,6 +8,7 @@ to parsee sentences.  A basic familiarity with Link Grammar is assumed.
 * `dict-lookup.scm` -- Look up individual words in the dictionary.
 * `parse.scm` -- Parse sentences.
 * `parse-disjuncts.scm` -- Get the disjuncts used in a parse.
-* `network-server.scm` and `netwwork-client.scm` -- A pair of examples,
+* `cross-space.scm` -- Use AtomSpace dictionaries.
+* `network-server.scm` and `network-client.scm` -- A pair of examples,
   implementing a server that performs parsing, and the client to
   communicate to the server.

--- a/examples/cross-space.scm
+++ b/examples/cross-space.scm
@@ -1,0 +1,82 @@
+;
+; cross-space.scm -- Demo of using an AtomSpace-backed dictionary.
+;
+; The Link Grammar parser can use dictionary data obtained from an
+; AtomSpace. This is typically needed when the dictionary is the
+; result of unsupervised grammar learning; specifically, the project
+; in the https://github.com/opencog/learn git repo.
+;
+; That project stores the dictionary in a format that is similar to,
+; but is distinctly different from the strict LG-compatible format.
+; Thus, there is a need to be able to correlate the AtomSpace
+; dictionary to the parse results.  This demo shows how to do this.
+;
+; See the `parse-disjuncts.scm` demo as a pre-requisite.
+; -----------------------------------------------------------------
+
+; Load the guile modules
+(use-modules (opencog) (opencog exec))
+(use-modules (opencog nlp) (opencog nlp lg-parse))
+(use-modules (opencog persist) (opencog persist-file))
+
+; Specify a location of a dictionary, and open it.
+(define fsn
+	(FileStorage "/usr/local/share/link-grammar/demo-atomese/atomese-dict.scm"))
+(cog-open fsn)
+
+; Set up a parse node. The arguments are as follows:
+;
+; The demo dictionary (above) can parse only one sentence: "level
+; playing field".  Don't change this, else the parse will fail.
+;
+; The (LgDictNode "demo-atomese") specifies an LG configuration file
+; that LG will recognize as being AtomSpace-backed. An invalid
+; specification will throw an error.
+;
+; The (NumberNode 4) specifies how many linkages to return.
+;
+; The (cog-atomspace) specifies the AtomSpace that contains the
+; dictionary. In this case, it will be the current dictionary.
+; This argument is optional; if it is absent, then the correlating
+; EvaluationLinks (shown below) will not be written into the curretnt
+; AtomSpace. The demo still works, but a key bit of info will be
+; missing.
+;
+; The fsn specifies the StorageNode containing the dictionary.
+; This argument is optional; if it is absent, the entire dictionary
+; MUST be present in the prior AtomSpace argument.  If the AtomSpace
+; argument is also missing, then the LG dictionary config (specified
+; in the LgDictNode) will be used.
+;
+(define pda
+	(LgParseDisjuncts
+		(PhraseNode "level playing field")
+		(LgDictNode "demo-atomese")
+		(NumberNode 4)
+      (cog-atomspace)
+      fsn))
+
+; Parse the example sentence.
+(cog-execute! pda)
+
+; To result will place EvaluationLinks matching up the parse results
+; with the dictionary contents.  Look at the entire contents of the
+; AtomSpace to get a clear idea:
+(cog-prt-atomspace)
+
+; One of the links will look like this:
+;
+;   (EvaluationLink
+;      (PredicateNode "*-LG connector string-*")
+;      (LgConnNode "C")
+;      (SetLink
+;        (WordNode "playing")
+;        (WordNode "field")))
+;   
+; This states that the LG connector "C" used in the parse corresponds to
+; the word-pair playing-field in the AtomSpace dictionary. If this seems
+; unclear, take a good look at the dictionary.  Gram classes look
+; similar, but different.
+;
+; ---------------------
+; That's all, folks!

--- a/examples/parse-disjuncts.scm
+++ b/examples/parse-disjuncts.scm
@@ -13,8 +13,6 @@
 (use-modules (opencog) (opencog exec))
 (use-modules (opencog nlp) (opencog nlp lg-parse))
 
-(use-modules (srfi srfi-1))
-
 ; Parse an example sentence
 (cog-execute!
 	(LgParseDisjuncts    ; There is also a "full" parse, demoed elsewhere.

--- a/opencog/nlp/lg-dict/LGDictNode.cc
+++ b/opencog/nlp/lg-dict/LGDictNode.cc
@@ -33,7 +33,7 @@ using namespace opencog;
 
 // ------------------------------------------------------
 // Convert LG errors to opencog log messges
-// Not static, its also used by LgParseNode.cc
+// Not static, its also used by LgParseLink.cc
 void error_handler(lg_errinfo *ei, void *data);
 void error_handler(lg_errinfo *ei, void *data)
 {

--- a/opencog/nlp/lg-parse/LGParseLink.cc
+++ b/opencog/nlp/lg-parse/LGParseLink.cc
@@ -113,7 +113,7 @@ void LGParseLink::init()
 	if (5 <= osz)
 	{
 		Type stot = oset[4]->get_type();
-	   if (not nameserver().isA(STORAGE_NODE, stot)
+	   if (not nameserver().isA(stot, STORAGE_NODE)
 		    and VARIABLE_NODE != stot and GLOB_NODE != stot)
 		throw InvalidParamException(TRACE_INFO,
 				"LGParseLink: Expecting StorageNode, got %s",
@@ -185,7 +185,7 @@ ValuePtr LGParseLink::execute(AtomSpace* as, bool silent)
 			"LGParseLink: Invalid outgoing set at 3; expecting AtomSpace");
 
 	if (5 <= _outgoing.size() and
-	   not nameserver().isA(STORAGE_NODE, _outgoing[4]->get_type()))
+	   not nameserver().isA(_outgoing[4]->get_type(), STORAGE_NODE))
 		throw InvalidParamException(TRACE_INFO,
 			"LGParseLink: Invalid outgoing set at 4; expecting StorageNode");
 

--- a/opencog/nlp/lg-parse/LGParseLink.cc
+++ b/opencog/nlp/lg-parse/LGParseLink.cc
@@ -24,13 +24,14 @@
 #include <atomic>
 #include <uuid/uuid.h>
 #include <link-grammar/link-includes.h>
+#include <link-grammar/dict-atomese.h>
 
 #include <opencog/atoms/atom_types/NameServer.h>
 #include <opencog/atoms/base/Node.h>
 #include <opencog/atoms/core/NumberNode.h>
 #include <opencog/atoms/value/LinkValue.h>
 #include <opencog/atomspace/AtomSpace.h>
-#include <opencog/persist/storage/storage_types.h>
+#include <opencog/persist/api/StorageNode.h>
 #include <opencog/nlp/lg-dict/LGDictNode.h>
 #include "LGParseLink.h"
 
@@ -192,6 +193,19 @@ ValuePtr LGParseLink::execute(AtomSpace* as, bool silent)
 	// per thread. Don't know why. So we have to set it every time,
 	// because we don't know what thread we are in.
 	lg_error_set_handler(error_handler, nullptr);
+
+	// Set up the dictionary config, if any.
+	// This must happen before ldn->get_dictionary() because the
+	// setup is stateful. This seems buggy, but is adequate for now.
+	if (4 <= _outgoing.size())
+	{
+		AtomSpacePtr asp = AtomSpaceCast(_outgoing[3]);
+		StorageNodePtr stnp;
+		if (5 <= _outgoing.size())
+			stnp = StorageNodeCast(_outgoing[4]);
+
+		lg_config_atomspace(asp, stnp);
+	}
 
 	// Get the dictionary
 	LgDictNodePtr ldn(LgDictNodeCast(_outgoing[1]));

--- a/opencog/nlp/lg-parse/LGParseLink.cc
+++ b/opencog/nlp/lg-parse/LGParseLink.cc
@@ -43,6 +43,8 @@ void error_handler(lg_errinfo *ei, void *data);
 ///         PhraseNode "this is a test."
 ///         LgDictNode "en"
 ///         NumberNode  6   -- optional, number of parses.
+///         AtomSpace  foo  -- optional, AtomSpace holdig dict info.
+///         StorageNode bar -- optional, StorageNode holding dict info.
 ///
 /// When executed, the result of parsing the phrase text, using the
 /// specified dictionary, is placed in the atomspace.  Execution
@@ -50,6 +52,20 @@ void error_handler(lg_errinfo *ei, void *data);
 /// optional NumberNode is present, then that will be the number of
 /// parses that are captured. If the NumberNode is not present, it
 /// defaults to four.
+///
+/// If the `LgDictNode` specified an AtomSpace-backed dictionary, and
+/// the fourth argument is present, then the dictionary word lookups
+/// will be performed from the specified AtomSpace.  Note that
+/// EvaluationLinks will be created in that AtomSpace, tying together
+/// the LG connector types to the AtomSpace connector types. This is
+/// the only reason for specifying an AtomSpace: to get back that info.
+///
+/// If the `LgDictNode` specified an AtomSpace-backed dictionary, and
+/// the fifth argument is present, then the dictionary word lookups
+/// will be performed from the specified StorageNode. Otherwise, if
+/// an AtomSpace is specified, but the StorageNode is not, the parser
+/// will use the AtomSpace contents only; the entire dictionary must
+/// be present in the AtomSpace.
 ///
 /// The LgParseLink is a kind of FunctionLink, and can thus be used in
 /// any expression that FunctionLinks can be used with.

--- a/opencog/nlp/lg-parse/LGParseLink.h
+++ b/opencog/nlp/lg-parse/LGParseLink.h
@@ -37,12 +37,12 @@ namespace opencog
 
 /// Link Grammar parser.
 ///
-/// An atomspace wrapper to the LG parser.
-/// The LGParseLink places a full parse into the atomspace, including
+/// An AtomSpace wrapper to the LG parser.
+/// The LGParseLink places a full parse into the AtomSpace, including
 /// the disjuncts and the link-instances.
 ///
 /// The LGParseMinimal ony places the words, word-sequence and links
-/// into the atomspace.
+/// into the AtomSpace.
 
 class LGParseLink : public FunctionLink
 {

--- a/opencog/nlp/lg-parse/README.md
+++ b/opencog/nlp/lg-parse/README.md
@@ -3,8 +3,8 @@ Link Grammar parsing
 ====================
 
 Perform a Link Grammar parse of a sentence, and insert the results into
-the AtomSpace.  This is compatible with the LG subset of the RelEx
-parse.
+the AtomSpace.  This was designed to be compatible with the LG subset of
+the RelEx parse. As of 2022, RelEx is obsolete and no longer supported.
 
 LgParseLink
 -----------
@@ -20,6 +20,8 @@ The expected format of an LgParseLink is:
         PhraseNode "this is a test."
         LgDictNode "en"
         NumberNode  6   -- optional, number of parses.
+        AtomSpace  foo  -- optional, AtomSpace holdig dict info.
+        StorageNode bar -- optional, StorageNode holding dict info.
 
 When executed, the result of parsing the phrase text, using the
 specified dictionary, is placed in the atomspace.  Execution
@@ -27,6 +29,20 @@ returns a SentenceNode pointing at the parse results.  If the third,
 optional NumberNode is present, then that will be the number of
 parses that are captured. If the NumberNode is not present, it
 defaults to four.
+
+If the `LgDictNode` specified an AtomSpace-backed dictionary, and
+the fourth argument is present, then the dictionary word lookups
+will be performed from the specified AtomSpace.  Note that
+`EvaluationLink`s will be created in that AtomSpace, tying together
+the LG connector types to the AtomSpace connector types. This is
+the only reason for specifying an AtomSpace: to get back that info.
+
+If the `LgDictNode` specified an AtomSpace-backed dictionary, and
+the fifth argument is present, then the dictionary word lookups
+will be performed from the specified `StorageNode`. Otherwise, if
+an AtomSpace is specified, but the `StorageNode` is not, the parser
+will use the AtomSpace contents only; the entire dictionary must
+be present in the AtomSpace.
 
 LgParseMinimal
 --------------
@@ -70,8 +86,8 @@ this means that there are two ways of getting parsed text into the
 atomspace: using this link, or using the RelEx server.  There are
 competing pros and cons of doing it each way:
 
-* The RelEx server is deprecated/obsolete. It still works, but there
-  no support for it any more. No bug-fixes, no active development.
+* The RelEx server is obsolete. It still works, but there no support
+  for it any more. No bug-fixes, no active development.
 
 * The RelEx server is a network server, and can be run on any
   network-connected machine.


### PR DESCRIPTION
Add full bi-directional support for AtomSpace-based dictionaries.

This allows parsing to to use not only AtomSpace dictionaries, but the parse results can be placed back into the *same* dictionary. This is needed, in order to update statistics on the dictionary usage.